### PR TITLE
hotfix : 온보딩을 건너뛴 후 생성한 첫 약속이 화면에 표시되지 않던 버그를 수정했습니다.

### DIFF
--- a/Maro/View/MainView.swift
+++ b/Maro/View/MainView.swift
@@ -35,9 +35,7 @@ private extension MainView {
             Spacer()
             promiseList
         }
-        .onAppear {
-            viewModel.onAppear()
-        }
+        .onAppear { viewModel.onAppear() }
     }
 
     var header: some View {

--- a/Maro/View/OnBoardingTabView.swift
+++ b/Maro/View/OnBoardingTabView.swift
@@ -147,8 +147,10 @@ private extension OnBoardingTabView {
             }
             BottomButtonView(type: .start, isButtonAvailable: true) {
                 viewModel.didTapButton {
-                        NotificationManager.shared.scheduleNotification()
-                        isShowingOnboarding = false
+                    UserDefaults.standard.set("01", forKey: "todayIndex")
+                    UserDefaults.standard.set(viewModel.content, forKey: "todayPromise")
+                    NotificationManager.shared.scheduleNotification()
+                    isShowingOnboarding = false
                 }
             }
         }

--- a/Maro/ViewModel/CreatePromiseViewModel.swift
+++ b/Maro/ViewModel/CreatePromiseViewModel.swift
@@ -41,6 +41,8 @@ final class CreatePromiseViewModel: ObservableObject {
         if isButtonAvailable() {
             guard let category = Category(string: selectedCategory) else { return }
             if count == 0 {
+                UserDefaults.standard.set("01", forKey: "todayIndex")
+                UserDefaults.standard.set(content, forKey: "todayPromise")
                 CoreDataManager.shared.createPromise(
                     content: content,
                     category: category,

--- a/Maro/ViewModel/MainViewModel.swift
+++ b/Maro/ViewModel/MainViewModel.swift
@@ -11,8 +11,8 @@ import Combine
 @MainActor
 final class MainViewModel: ObservableObject {
     @Published var promises: Array<PromiseEntity> = []
-    @Published var todayIndex: String? = UserDefaults.standard.string(forKey: "todayIndex")
-    @Published var todayPromise: String? = UserDefaults.standard.string(forKey: "todayPromise")
+    @Published var todayIndex: String? = ""
+    @Published var todayPromise: String? = ""
     @Published var isShowingLink = false
     @Published var isShowongAlert = false
     @Published var refreshTrigger = false
@@ -20,6 +20,11 @@ final class MainViewModel: ObservableObject {
         didSet {
             if log != oldValue {
                 self.setTodaysPromise()
+            }
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.todayIndex = UserDefaults.standard.string(forKey: "todayIndex")
+                self.todayPromise = UserDefaults.standard.string(forKey: "todayPromise")
             }
             UserDefaults.standard.set(log, forKey: Constant.log)
         }
@@ -74,7 +79,7 @@ private extension MainViewModel {
             completion()
         }
     }
-        
+    
     func setTodaysPromise() {
         let randomPromise = self.promises.randomElement()
         guard let promise = randomPromise else { return }


### PR DESCRIPTION
# HOTFIX

화면에 표시되는 랜덤 약속은 UserDefaults를 통해 표시됩니다.

NotificationCenter의 selector를 leaveLog 함수로 변경 후 첫 약속이 등록되었을 때 setTodaysPromise 함수가 발생하지 않게 되었고, 이에 오늘의 약속을 세팅하는 작업 또한 진행되지 않는 것으로 확인했습니다.

이에 온보딩에서 첫 약속을 생성하는 경우,

그리고 건너뛰기를 터치한 후 메인 화면에서 첫 약속을 생성하는 경우에 모두 UserDefaults에 값을 추가하는 로직을 구현했습니다.

그리고 MainView의 onAppear 메소드 발생 시 leaveLog 함수가 작동하게 되는데 해당 함수 내부 로직에 하기 로직을 추가하여 UserDefaults 값이 매번 할당되도록 하였습니다.

```swift
DispatchQueue.main.async { [weak self] in
   guard let self = self else { return }
   self.todayIndex = UserDefaults.standard.string(forKey: "todayIndex")
   self.todayPromise = UserDefaults.standard.string(forKey: "todayPromise")
}
```