### PR TITLE
fix : 텍스트가 긴 약속의 일부가 화면에 표시되지 않던 버그를 수정했습니다.

### DIFF
--- a/Maro/View/MainView.swift
+++ b/Maro/View/MainView.swift
@@ -90,7 +90,6 @@ private extension MainView {
                         .lineLimit(2)
                         .font(.title3)
                         .foregroundColor(.white)
-                        .padding(.bottom, 28)
                         .frame(minWidth: 0, maxWidth: 264)
                 }
 
@@ -110,7 +109,8 @@ private extension MainView {
                             Capsule().stroke(.white, lineWidth: 1)
                         }
                 }
-                .padding(.bottom, 56)
+                .padding(.top, 40)
+                .padding(.bottom, 31)
                 .alert(isPresented: $viewModel.isShowongAlert) {
                     Alert(
                         title: Text("알림"),


### PR DESCRIPTION
multilineText의 패딩 설정이 원인이었습니다.
해당 패딩을 삭제하고 새 약속 만들기 버튼의 패딩을 조절했습니다.